### PR TITLE
fixup godot tests to not load duplicate godot assemblies

### DIFF
--- a/mono/dodge_the_creeps/RiderTestRunner/NetCoreRunner.cs
+++ b/mono/dodge_the_creeps/RiderTestRunner/NetCoreRunner.cs
@@ -47,7 +47,19 @@ namespace RiderTestRunner
         }
 
         private Assembly DefaultOnResolving(AssemblyLoadContext context, AssemblyName assemblyName)
-        { 
+        {
+            var alreadyLoadedMatch = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(loadedAssembly =>
+            {
+                var name = loadedAssembly.GetName().Name;
+                return name != null &&
+                       name.Equals(assemblyName.Name);
+            });
+
+            if (alreadyLoadedMatch != null)
+            {
+                return alreadyLoadedMatch;
+            }
+            
             var dir = new FileInfo(_runnerAssemblyPath).Directory;
             if (dir == null) return null;
             var file = new FileInfo(Path.Combine(dir.FullName, $"{assemblyName.Name}.dll"));

--- a/mono/dodge_the_creeps/projects/GodotNUnitTestProject/UnitTest1.cs
+++ b/mono/dodge_the_creeps/projects/GodotNUnitTestProject/UnitTest1.cs
@@ -13,9 +13,9 @@ namespace TestProject1
         {
             int i = 0;
             Console.WriteLine("Testsss");
-            //GD.Print("NUnitTest");
-            // var main = (Main)ResourceLoader.Load<PackedScene>("res://Main.tscn").Instance();
-            // Assert.AreEqual("Main", main.Name);
+            GD.Print("NUnitTest");
+            var main = (Main)ResourceLoader.Load<PackedScene>("res://Main.tscn").Instantiate();
+            Assert.AreEqual("Main", main.Name.ToString());
         }
     }
 }

--- a/mono/dodge_the_creeps/projects/GodotXUnitTestProject/MyTest.cs
+++ b/mono/dodge_the_creeps/projects/GodotXUnitTestProject/MyTest.cs
@@ -12,11 +12,11 @@ namespace TestProject1
         {
             int i = 0;
             Console.WriteLine("Testsss");
-            //GD.Print("XUnitTest");
-            // var main = (Main)ResourceLoader.Load<PackedScene>("res://Main.tscn").Instance();
-            // GD.Print(System.Threading.Thread.CurrentThread.IsBackground);
-            // //System.Environment.CurrentManagedThreadId
-            // Assert.Equal("Main", main.Name);
+            GD.Print("XUnitTest");
+            var main = (Main)ResourceLoader.Load<PackedScene>("res://Main.tscn").Instantiate();
+            GD.Print(System.Threading.Thread.CurrentThread.IsBackground);
+            //System.Environment.CurrentManagedThreadId
+            Assert.Equal("Main", main.Name);
         }
     }
 }


### PR DESCRIPTION
As I was migrating my project to godot 4 I noticed the net core runner would throw an AccessViolationException when attempting to interact with nodes.

From what I could see, duplicate versions of both `GodotSharp` and the project under test were being loaded into the `AppDomain` since the paths were different in `DefaultOnResolving`

This change makes it so any assemblies that have a matching name will be reused instead of duplicated.

Feel free to disregard if this isn't desirable. 

Thanks for all the work on the rider plugin :-)